### PR TITLE
Helix - Update languages.toml

### DIFF
--- a/.config/helix/languages.toml
+++ b/.config/helix/languages.toml
@@ -1,23 +1,24 @@
 [[language]]
 name = "rust"
 comment-token = "//"
+language-servers = ["rust"]
 
 [[language]]
 name = "html"
 indent = { tab-width = 2, unit = "  " }
-language-servers = [ "emmet-ls" ]
+language-servers = ["emmet-ls"]
 formatter = { command = "emmet-ls" , args = ["--stdin"] }
- 
+
 [[language]]
 name = "css"
 indent = { tab-width = 2, unit = "  " }
-language-servers = [ "css-languageserver" ]
+language-servers = ["css-languageserver"]
 formatter = { command = "css-languageserver" , args = ["--stdin"] }
 
 [[language]]
 name = "json"
 indent = { tab-width = 2, unit = "  " }
-language-servers = [ "json-languageserver" ]
+language-servers = ["json-languageserver"]
 formatter = { command = "json-languageserver" , args = ["--stdin"] }
  
 [[language]]
@@ -28,14 +29,42 @@ file-types = ["go"]
 roots = ["Gopkg.toml", "go.mod"]
 auto-format = true
 comment-token = "//"
-language-servers = [ "gopls" ]
+language-servers = ["gopls"]
 indent = { tab-width = 4, unit = "\t" }
 
 [[language]]
 name = "astro"
-language-servers = [ "astro-ls" ]
+language-servers = ["astro-ls"]
 formatter = { command = "astro-ls", args = ["--stdin"]}
 
 [[language]]
 name = "typescript"
-language-servers = [ "deno" ]
+language-servers = ["deno"]
+
+[language-server.rust]
+command = "rust-analyzer"
+args = [""]
+
+[language-server.emmet-ls]
+command = "emmet-ls"
+args = ["--stdio"]
+
+[language-server."css-languageserver"]
+command = "css-languageserver"
+args = ["--stdio"]
+
+[language-server."json-languageserver"]
+command = "json-languageserver"
+args = ["--stdio"]
+
+[language-server.gopls]
+command = "gopls"
+args = [""]
+
+[language-server."astro-ls"]
+command = "astro-ls"
+args = ["--stdio"]
+
+[language-server.deno]
+command = "deno"
+args = ["lsp"]

--- a/.config/helix/languages.toml
+++ b/.config/helix/languages.toml
@@ -5,19 +5,19 @@ comment-token = "//"
 [[language]]
 name = "html"
 indent = { tab-width = 2, unit = "  " }
-language-server = { command = "emmet-ls", args = ["--stdio"] }
+language-servers = [ "emmet-ls" ]
 formatter = { command = "emmet-ls" , args = ["--stdin"] }
  
 [[language]]
 name = "css"
 indent = { tab-width = 2, unit = "  " }
-language-server = { command = "css-languageserver", args = ["--stdio"] }
+language-servers = [ "css-languageserver" ]
 formatter = { command = "css-languageserver" , args = ["--stdin"] }
 
 [[language]]
 name = "json"
 indent = { tab-width = 2, unit = "  " }
-language-server = { command = "json-languageserver", args = ["--stdio"] }
+language-servers = [ "json-languageserver" ]
 formatter = { command = "json-languageserver" , args = ["--stdin"] }
  
 [[language]]
@@ -28,16 +28,14 @@ file-types = ["go"]
 roots = ["Gopkg.toml", "go.mod"]
 auto-format = true
 comment-token = "//"
-language-server = { command = "gopls" }
+language-servers = [ "gopls" ]
 indent = { tab-width = 4, unit = "\t" }
 
 [[language]]
 name = "astro"
-language-server = { command = "astro-ls", args = ["--stdio"]}
+language-servers = [ "astro-ls" ]
 formatter = { command = "astro-ls", args = ["--stdin"]}
 
 [[language]]
 name = "typescript"
-language-server = { command = "deno", args = ["lsp"] }
-config = { enable = true }
-
+language-servers = [ "deno" ]


### PR DESCRIPTION
Accordingly to recent documentation,

language-servers is correct field name

https://docs.helix-editor.com/languages.html#configuring-language-servers-for-a-language

otherwise, with current config and latest version of helix, it throws an error when parsing config